### PR TITLE
Dev 1.1 changes

### DIFF
--- a/feoh_matchup_tool/src/feoh_matchup_tool.rs
+++ b/feoh_matchup_tool/src/feoh_matchup_tool.rs
@@ -188,8 +188,6 @@ impl Application for MatchupTool {
                             counters_column = counters_column.push(row![
                                 image::viewer(img.unwrap().clone()).width(Length::Fixed(32.)).height(Length::Fixed(32.)).scale_step(0.),
                                 text(champ),
-                                text(" - "),
-                                text(sfty),
                             ]
                             .align_items(Alignment::Center)
                             .spacing(10)
@@ -199,8 +197,6 @@ impl Application for MatchupTool {
                             counters_column_middle = counters_column_middle.push(row![
                                 image::viewer(img.unwrap().clone()).width(Length::Fixed(32.)).height(Length::Fixed(32.)).scale_step(0.),
                                 text(champ),
-                                text(" - "),
-                                text(sfty),
                             ]
                             .align_items(Alignment::Center)
                             .spacing(10)
@@ -210,8 +206,6 @@ impl Application for MatchupTool {
                             counters_column_right = counters_column_right.push(row![
                                 image::viewer(img.unwrap().clone()).width(Length::Fixed(32.)).height(Length::Fixed(32.)).scale_step(0.),
                                 text(champ),
-                                text(" - "),
-                                text(sfty),
                             ]
                             .align_items(Alignment::Center)
                             .spacing(10)

--- a/feoh_matchup_tool/src/feoh_matchup_tool.rs
+++ b/feoh_matchup_tool/src/feoh_matchup_tool.rs
@@ -179,7 +179,7 @@ impl Application for MatchupTool {
         }
         let ofl = &self.old_file_location_string;
         let old_data_file_location_input: iced::widget::TextInput<'_, Message, Renderer> = text_input("Location to import", ofl)
-        .on_input(Message::OldFileLocationChanged(ofl));
+        .on_input(Message::OldFileLocationChanged);
         
 
         let content = column![
@@ -314,13 +314,15 @@ impl Application for MatchupTool {
                 Command::none()
             }
             Message::ImportOldData(pathstr) => {
-                println!("{}",pathstr);
-                /*
                 let path = PathBuf::from(pathstr);
+                println!("{}",path.display());
                 matchup_data_reader::import_old_data_file(&mut self.champion_obj_array, path);
                 write_file(export_champ_to_raw(&self.champion_obj_array));
-                */
-                self.update(Message::Closed)
+                match self.selected_champion {
+                    Some(champ) => self.update(Message::Selected(champ)),
+                    None => self.update(Message::Selected(ChampEnum::Aatrox)),
+                }
+                
             }
             Message::OldFileLocationChanged(ofl) => {
                 self.old_file_location_string = ofl;

--- a/feoh_matchup_tool/src/feoh_matchup_tool.rs
+++ b/feoh_matchup_tool/src/feoh_matchup_tool.rs
@@ -137,6 +137,7 @@ impl Application for MatchupTool {
         .on_close(Message::ChampToAddClosed);
 
         let counterstring_itr = self.text.lines();
+        let mut counters_title: Row<'_, Message> = row!().align_items(Alignment::Start).spacing(10).width(Length::Fill);
         let mut counters_structure: Row<'_, Message> = row!().align_items(Alignment::Start).spacing(10).width(Length::Fill);
         let mut counters_column: Column<'_, Message> = column!().align_items(Alignment::Start).spacing(10).width(Length::Fill);
         let mut counters_column_middle: Column<'_, Message> = column!().align_items(Alignment::Start).spacing(10).width(Length::Fill);
@@ -148,9 +149,17 @@ impl Application for MatchupTool {
                 if self.text.is_empty() {
                     counters_column = counters_column.push(text("This champion has no counters!"));
                 } else {
-                    counters_column = counters_column.push(row![
+                    counters_title = counters_title.push(row![
                         image::viewer(self.selected_image.clone()).width(Length::Fixed(32.)).height(Length::Fixed(32.)).scale_step(0.),
-                        text(format!("{} Safe Counters: ", self.selected_champion.unwrap())).size(24),
+                        text(format!("{} Counters", self.selected_champion.unwrap())).size(28),
+                    ]
+                    .align_items(Alignment::Center)
+                    .spacing(10)
+                    .padding(0),
+                    );
+
+                    counters_column = counters_column.push(row![
+                        text(format!("Safe Counters:")).size(24),
                     ]
                     .align_items(Alignment::Center)
                     .spacing(10)
@@ -261,16 +270,18 @@ impl Application for MatchupTool {
             .spacing(10)
             .padding(50),
             row![
-                horizontal_space(700),
+                horizontal_space(685),
                 old_data_file_location_input,
                 button("Import old data format file").on_press(Message::ImportOldData(ofl.to_string())),
             ]
             .align_items(Alignment::Center)
             .spacing(10)
             .padding(50),
-            row![
+            column![
+                counters_title,
                 counters_structure,
             ]
+            .width(Length::Fill)
             .align_items(Alignment::Center)
             .spacing(10)
             .padding(50),
@@ -318,8 +329,9 @@ impl Application for MatchupTool {
                 Command::none()
             }
             Message::Closed => {
-                self.text = "Select a champion".to_string();
+                self.text = "".to_string();
                 self.selected_image = self.get_default_image();
+                self.selected_champion = None;
                 Command::none()
             }
             Message::CounterAdded(obj, ms) => {

--- a/feoh_matchup_tool/src/matchup_data_reader.rs
+++ b/feoh_matchup_tool/src/matchup_data_reader.rs
@@ -52,12 +52,15 @@ pub fn import_old_data_file(champvec: &mut Vec<champion_struct::Champion>, path:
             None => continue,
         };
         for proven_cntr in &equiv_old.provenCounters {
+            if champ.counters.contains(&(proven_cntr.clone(),champion_struct::MatchupSafety::Safe)) {continue;}
             champ.counters.push((proven_cntr.clone(), champion_struct::MatchupSafety::Safe));
         }
         for normal_cntr in &equiv_old.counters {
+            if champ.counters.contains(&(normal_cntr.clone(),champion_struct::MatchupSafety::Normal)) {continue;}
             champ.counters.push((normal_cntr.clone(), champion_struct::MatchupSafety::Normal));
         }
         for playable_cntr in &equiv_old.playableCounters {
+            if champ.counters.contains(&(playable_cntr.clone(),champion_struct::MatchupSafety::Playable)) {continue;}
             champ.counters.push((playable_cntr.clone(), champion_struct::MatchupSafety::Playable));
         }
     }

--- a/feoh_matchup_tool/src/matchup_data_reader/champion_struct.rs
+++ b/feoh_matchup_tool/src/matchup_data_reader/champion_struct.rs
@@ -172,3 +172,17 @@ pub fn export_champ_to_raw (champvec: &Vec<Champion>) -> Vec<RawData> {
     return out_vec;
 }
 
+// The raw data format of the old Matchup Tool written in Java
+#[allow(non_snake_case)]
+#[derive(Serialize, Deserialize)]
+pub struct OldFormat {
+    //pub id: usize,
+    pub championId: String,
+    pub championName: String,
+    pub counters: Vec<String>,
+    pub counterCompositions: Vec<String>,
+    pub provenCounters: Vec<String>,
+    pub playableCounters: Vec<String>,
+    pub ireliaWins: usize,
+    pub ireliaLosses: usize,
+}


### PR DESCRIPTION
Implemented a method to import data files from the old matchup tool into the new one, merging the data files.
Changed counter display to three seperate columns for the three different matchup safeties.
Removed matchup safety String from the counter names.
Added a Title to the counters display.
Improved combo box closing behaviour.